### PR TITLE
fix: react-native-svg web 端

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "react-art": "^17.0.1",
     "react-native-web": "^0.14.10",
     "react-native-web-linear-gradient": "^1.1.1",
-    "react-native-web-maps": "^0.3.0",
-    "svgs": "^4.1.1"
+    "react-native-web-maps": "^0.3.0"
   },
   "config": {
     "commitizen": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export default (api: IApi) => {
         // Directly match react-native to react-native-web.
         'react-native$': path.resolve(__dirname,'react-native-web'),
         // Alias react-native-svg to svgs
-        'react-native-svg$': 'svgs',
+        'react-native-svg$': 'react-native-svg/lib/commonjs/ReactNativeSVG',
         // Alias react-native-linear-gradient to web
         'react-native-linear-gradient': 'react-native-web-linear-gradient',
         // Alias react-native-maps to web


### PR DESCRIPTION
`createAnimatedComponent` does not support stateless functional components; use a class component instead.

react-native-svg 已经提供了 web 端组件，svg 的组件是函数的，和 Animated.createAnimatedComponent 无法配合使用。

实现/业务代码可以参考[onlyling/xant](https://github.com/onlyling/xant) components/loading/circular.tsx，如果要预览效果，可以看 refactor 分支

![QQ20210430-115602-HD](https://user-images.githubusercontent.com/9999765/116646620-1ca4db80-a9ab-11eb-9639-28770a9991d3.gif)
